### PR TITLE
refactor: remove annotations future import

### DIFF
--- a/src/conjecture/__init__.py
+++ b/src/conjecture/__init__.py
@@ -3,7 +3,6 @@ conjecture.
 
 a pythonic assertion framework
 """
-from __future__ import annotations
 
 from conjecture.base import AllOfConjecture, AnyOfConjecture, Conjecture
 from conjecture.general import all_of, any_of, anything, has, none

--- a/src/conjecture/base.py
+++ b/src/conjecture/base.py
@@ -1,5 +1,4 @@
 """base conjecture classes."""
-from __future__ import annotations
 
 import collections.abc
 import typing
@@ -59,7 +58,7 @@ class Conjecture:
         """
         return self.resolve(other)
 
-    def __invert__(self) -> Conjecture:
+    def __invert__(self) -> "Conjecture":
         """
         Invert conjecture.
 
@@ -69,7 +68,7 @@ class Conjecture:
         """
         return Conjecture(lambda value: not self.resolve(value))
 
-    def __or__(self, other: object) -> Conjecture:
+    def __or__(self, other: object) -> "Conjecture":
         """
         Combine using any of.
 
@@ -85,7 +84,7 @@ class Conjecture:
 
         return AnyOfConjecture((self, other))
 
-    def __and__(self, other: object) -> Conjecture:
+    def __and__(self, other: object) -> "Conjecture":
         """
         Combine using all of.
 

--- a/src/conjecture/general.py
+++ b/src/conjecture/general.py
@@ -1,5 +1,4 @@
 """general conjectures."""
-from __future__ import annotations
 
 import conjecture.base
 

--- a/src/conjecture/object.py
+++ b/src/conjecture/object.py
@@ -1,5 +1,4 @@
 """object conjectures."""
-from __future__ import annotations
 
 import typing
 

--- a/src/conjecture/rich.py
+++ b/src/conjecture/rich.py
@@ -1,5 +1,4 @@
 """rich comparison conjectures."""
-from __future__ import annotations
 
 import abc
 import typing

--- a/src/conjecture/sized.py
+++ b/src/conjecture/sized.py
@@ -1,5 +1,4 @@
 """sized conjectures."""
-from __future__ import annotations
 
 import collections.abc
 import typing

--- a/src/conjecture/string.py
+++ b/src/conjecture/string.py
@@ -1,5 +1,4 @@
 """string conjectures."""
-from __future__ import annotations
 
 import typing
 


### PR DESCRIPTION
## Description

`annotations` didn't make the 3.10 cut, better to strip it from the codebase.

## Motivation and Context

Have shed format the code without converting Union types.

## How Has This Been Tested?

Tests pass locally as does manual prodding.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

