### PR TITLE
feat: add has_key conjecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Matching anything.
 >>> assert "abc" == conjecture.anything()
 ```
 
+#### Mapping
+
+Matching keys.
+
+```pycon
+>>> import conjecture
+>>> assert {"a": 1} == conjecture.has_key("a")
+>>> assert {"a": 1} == conjecture.has_key("a", of=1)
+>>> assert {"a": 1} == conjecture.has_key("a", of=conjecture.less_than(5))
+```
+
 #### Object
 
 Matching instances of a class.

--- a/src/conjecture/__init__.py
+++ b/src/conjecture/__init__.py
@@ -6,6 +6,7 @@ a pythonic assertion framework
 
 from conjecture.base import AllOfConjecture, AnyOfConjecture, Conjecture
 from conjecture.general import all_of, any_of, anything, has, none
+from conjecture.mapping import has_key
 from conjecture.object import equal_to, has_attribute, instance_of
 from conjecture.rich import (
     greater_than,
@@ -29,6 +30,7 @@ __all__ = (
     "greater_than",
     "has",
     "has_attribute",
+    "has_key",
     "instance_of",
     "length_of",
     "less_than_or_equal_to",

--- a/src/conjecture/mapping.py
+++ b/src/conjecture/mapping.py
@@ -1,0 +1,35 @@
+"""mapping conjectures."""
+
+import collections.abc
+
+import conjecture.base
+
+sentinel = object()
+
+
+def has_key(value: str, of: object = sentinel) -> conjecture.base.Conjecture:
+    """
+    Has attribute.
+
+    Propose that the value has the given key
+
+    >>> assert value == conjecture.has_key("foo")
+    >>> assert value == conjecture.has_key("foo", of=5)
+    >>> assert value == conjecture.has_key("foo", of=conjecture.less_than(10))
+
+    :param value: the name of the key
+    :param of: an optional value or conjecture to compare the key value against
+
+    :return: a conjecture object
+    """
+    # pylint: disable=invalid-name
+    # of is a perfectly valid name.
+
+    if of is sentinel:
+        return conjecture.base.Conjecture(
+            lambda x: isinstance(x, collections.abc.Mapping) and value in x
+        )
+
+    return conjecture.base.Conjecture(
+        lambda x: isinstance(x, collections.abc.Mapping) and x.get(value) == of
+    )

--- a/src/conjecture/object.py
+++ b/src/conjecture/object.py
@@ -55,7 +55,7 @@ def has_attribute(value: str, of: object = sentinel) -> conjecture.base.Conjectu
     # pylint: disable=invalid-name
     # of is a perfectly valid name.
 
-    if of == sentinel:
+    if of is sentinel:
         return conjecture.base.Conjecture(lambda x: hasattr(x, value))
 
     return conjecture.base.Conjecture(lambda x: getattr(x, value, sentinel) == of)

--- a/tests/unit/test_has_key.py
+++ b/tests/unit/test_has_key.py
@@ -1,0 +1,108 @@
+"""
+Tests for :meth:`conjecture.has_key`.
+"""
+
+import string
+
+import hypothesis
+import hypothesis.strategies as st
+
+import conjecture
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    other=st.integers(),
+)
+def test_should_match_when_key_exists(value: str, other: int) -> None:
+    """
+    has_key() should match when key exists.
+    """
+    mapping = {value: other}
+
+    assert conjecture.has_key(value).resolve(mapping)
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    key=st.text(alphabet=string.ascii_letters, min_size=1),
+    other=st.integers(),
+)
+def test_should_not_match_when_key_doesnt_exists(
+    value: str,
+    key: str,
+    other: int,
+) -> None:
+    """
+    has_key() should not match when key doesn't exist.
+    """
+    hypothesis.assume(value != key)
+
+    mapping = {key: other}
+
+    assert not conjecture.has_key(value).resolve(mapping)
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    other=st.integers(),
+)
+def test_should_match_when_key_value_matches(value: str, other: int) -> None:
+    """
+    has_key() should match when key value matches.
+    """
+    mapping = {value: other}
+
+    assert conjecture.has_key(value, of=other).resolve(mapping)
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    wrong=st.integers(),
+    other=st.integers(),
+)
+def test_should_not_match_when_key_value_doesnt_match(
+    value: str,
+    wrong: int,
+    other: int,
+) -> None:
+    """
+    has_key() should not match when key value doesn't match.
+    """
+    hypothesis.assume(wrong != other)
+
+    mapping = {value: wrong}
+
+    assert not conjecture.has_key(value, of=other).resolve(mapping)
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    other=st.integers(),
+)
+def test_should_match_when_key_value_matches_conjecture(value: str, other: int) -> None:
+    """
+    has_key() should match when key value matches conjecture.
+    """
+    mapping = {value: other}
+
+    always = conjecture.has(lambda x: True)
+
+    assert conjecture.has_key(value, of=always).resolve(mapping)
+
+
+@hypothesis.given(
+    value=st.text(alphabet=string.ascii_letters, min_size=1),
+    other=st.integers(),
+)
+def test_should_not_match_when_key_value_doesnt_match_conjecture(
+    value: str, other: int
+) -> None:
+    """
+    has_key() should not match when key value doesn't match conjecture.
+    """
+    mapping = {value: other}
+
+    never = conjecture.has(lambda x: False)
+
+    assert not conjecture.has_key(value, of=never).resolve(mapping)


### PR DESCRIPTION
## Description

add `has_key` conjecture. 

## Motivation and Context

Fixes #4 

## How Has This Been Tested?

```pycon
>>> import conjecture
>>> assert {"a": 1} == conjecture.has_key("a")
>>> assert {"a": 1} == conjecture.has_key("a", of=1)
>>> assert {"a": 1} == conjecture.has_key("a", of=conjecture.less_than(5))
>>> assert {"a": 1} == conjecture.has_key("b")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> assert {"a": 1} == conjecture.has_key("a", of=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> assert {"a": 1} == conjecture.has_key("a", of=conjecture.greater_than(5))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

